### PR TITLE
gcc 9.1 fix

### DIFF
--- a/dev/floyd_speak/parts/immer-master/immer/detail/combine_standard_layout.hpp
+++ b/dev/floyd_speak/parts/immer-master/immer/detail/combine_standard_layout.hpp
@@ -22,7 +22,7 @@
 
 #include <type_traits>
 
-#if __GNUC__ == 7 || __GNUC_MINOR__ == 1
+#if __GNUC__ == 7 && __GNUC_MINOR__ == 1
 #define IMMER_BROKEN_STANDARD_LAYOUT_DETECTION 1
 #define immer_offsetof(st, m) ((std::size_t) &(((st*)0)->m))
 #else


### PR DESCRIPTION
To get immer support for visual studio, consider getting the latest immer version. This is just a bugfix.